### PR TITLE
Implements skip password valildation on blank/generated passwords

### DIFF
--- a/app/views/settings/_account_policy_settings.html.erb
+++ b/app/views/settings/_account_policy_settings.html.erb
@@ -1,7 +1,9 @@
 <p><label><%= l(:rap_setting_password_complexity) %></label></p>
+ 
+
 <p>
 	<%= l(:rap_setting_password_complexity_a) %>
-	<%= text_field_tag 'settings[password_complexity]', @settings[:password_complexity], size: 1 %>
+    <label><%= l(:exception_handler_label_email_format)%></label><%= select_tag 'settings[password_complexity]', options_for_select([0,1,2,3,4], @settings[:password_complexity]) %>
 	<%= l(:rap_setting_password_complexity_b) %>
 	</br>
 	<%= l(:rap_setting_password_upper_case)   %></br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
   rap_setting_password_numerical:     '* Numerical (0-9)'
   rap_setting_password_non_alphanum:  '* Non-alphanumeric (!$#,)'
 
-  rap_error_password_complexity:      'Passwords must contain characters from %{complexity} of the following character classes: upper case (A-Z), lower case (a-z), numbers (0-9) and non-alphanumric (!$#,).'
+  rap_error_password_complexity:      'Passwords must contain characters from %{complexity} of the following character classes: upper case (A-Z), lower case (a-z), numbers (0-9) and non-alphanumeric (!$#,).'
 
 
     # == password expiry == #

--- a/lib/redmine_account_policy/user_patch.rb
+++ b/lib/redmine_account_policy/user_patch.rb
@@ -14,10 +14,13 @@ module RedmineAccountPolicy
 				# == password complexity AND password reuse== #
 
 				def validate_password_length_with_account_policy
+					return if password.blank? && generate_password?
 					validate_password_length_without_account_policy
+					
+					if !password.blank?
 
-					errors.add(:base, l(:rap_error_password_complexity)) unless complex_enough?(password)
-
+						errors.add(:base, l(:rap_error_password_complexity, complexity: Setting.plugin_redmine_account_policy[:password_complexity])) unless complex_enough?(password)
+					end		
 					#TODO: min_unique = Setting.plugin_redmine_account_policy[:password_max_age].to_i
 					#errors.add(:base, l(:rap_error_password_reuse, min_unique)) unless unique_enough?(password)
 				end


### PR DESCRIPTION
Also - enhancements:

Implements drop-down count list in Configuration page (text box allowed integers greater than number of possible character classes)

Fixed typo in password validation message
-plaintext "%{complexity}" was printed instead of actual complexity setting
-alphanumric to alphanumeric
