### PR TITLE
Grey out change password option on change lockout

### DIFF
--- a/app/views/hooks/redmine_account_policy/_view_my_account_contextual.erb
+++ b/app/views/hooks/redmine_account_policy/_view_my_account_contextual.erb
@@ -1,0 +1,2 @@
+
+<%=content_tag(:span, l(:button_change_password), :style => "color:gray", :class=>"icon icon-passwd", :title => l(:rap_alt_change_passwords_not_allowed, time_of_lockout_in_hours: (Setting.plugin_redmine_account_policy[:password_min_age].to_i * 24).to_s)) unless @user.change_password_allowed? %>

--- a/app/views/settings/_account_policy_settings.html.erb
+++ b/app/views/settings/_account_policy_settings.html.erb
@@ -1,7 +1,9 @@
 <p><label><%= l(:rap_setting_password_complexity) %></label></p>
+ 
+
 <p>
 	<%= l(:rap_setting_password_complexity_a) %>
-	<%= text_field_tag 'settings[password_complexity]', @settings[:password_complexity], size: 1 %>
+    <label><%= l(:exception_handler_label_email_format)%></label><%= select_tag 'settings[password_complexity]', options_for_select([0,1,2,3,4], @settings[:password_complexity]) %>
 	<%= l(:rap_setting_password_complexity_b) %>
 	</br>
 	<%= l(:rap_setting_password_upper_case)   %></br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
   rap_setting_password_numerical:     '* Numerical (0-9)'
   rap_setting_password_non_alphanum:  '* Non-alphanumeric (!$#,)'
 
-  rap_error_password_complexity:      'Passwords must contain characters from %{complexity} of the following character classes: upper case (A-Z), lower case (a-z), numbers (0-9) and non-alphanumric (!$#,).'
+  rap_error_password_complexity:      'Passwords must contain characters from %{complexity} of the following character classes: upper case (A-Z), lower case (a-z), numbers (0-9) and non-alphanumeric (!$#,).'
 
 
     # == password expiry == #

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
   rap_setting_password_min_unique_a:  'TODO: (Redmine already does it for last password). Ensure previous'
   rap_setting_password_min_unique_b:  'passwords are unique'
 
+
     # == invalid logins lockout == #
   rap_setting_invalid_logins:         'Invalid Login Attempts'
   rap_setting_invalid_logins_a:       'Lock account for'
@@ -35,6 +36,8 @@ en:
   rap_notice_invalid_logins_remaining: 'attempts remaining.'
 
   rap_notice_account_lockout:         'Your account has been locked due to too many login attempts. Please wait for '
+
+  rap_alt_change_passwords_not_allowed:  'You may not change your password within %{time_of_lockout_in_hours} hours of your last change'
 
   rap_mail_subject_login_failure:     'Failed Login Attempt'
   rap_mail_subject_login_lockout:     'Maximum Login Attempts Reached - Account temporarily locked'
@@ -51,4 +54,3 @@ en:
 
     # == daily cron == #
   rap_setting_account_policy_checked_on: 'Account policies last checked on'
-

--- a/init.rb
+++ b/init.rb
@@ -5,6 +5,7 @@ require_dependency 'redmine_account_policy/controller_account_success_authentica
 require_dependency 'redmine_account_policy/mailer_patch'
 require_dependency 'redmine_account_policy/my_controller_patch'
 require_dependency 'redmine_account_policy/user_patch'
+require_dependency 'redmine_account_policy/hooks'
 
 Redmine::Plugin.register :redmine_account_policy do
 	name 'Redmine Account Policy plugin'

--- a/lib/redmine_account_policy/hooks.rb
+++ b/lib/redmine_account_policy/hooks.rb
@@ -1,0 +1,15 @@
+module RedmineUserAccounts
+	class Hooks < Redmine::Hook::ViewListener
+
+		# This just renders the partial in
+		# app/views/hooks/my_plugin/_view_issues_form_details_bottom.rhtml
+		# The contents of the context hash is made available as local variables to the partial.
+		#
+		# Additional context fields
+		#   :issue  => the issue this is edited
+		#   :f      => the form object to create additional fields
+		render_on :view_my_account_contextual,
+			:partial => 'hooks/redmine_account_policy/view_my_account_contextual'
+
+		end
+end

--- a/lib/redmine_account_policy/user_patch.rb
+++ b/lib/redmine_account_policy/user_patch.rb
@@ -14,10 +14,13 @@ module RedmineAccountPolicy
 				# == password complexity AND password reuse== #
 
 				def validate_password_length_with_account_policy
+					return if password.blank? && generate_password?
 					validate_password_length_without_account_policy
+					
+					if !password.blank?
 
-					errors.add(:base, l(:rap_error_password_complexity)) unless complex_enough?(password)
-
+						errors.add(:base, l(:rap_error_password_complexity, complexity: Setting.plugin_redmine_account_policy[:password_complexity])) unless complex_enough?(password)
+					end		
 					#TODO: min_unique = Setting.plugin_redmine_account_policy[:password_max_age].to_i
 					#errors.add(:base, l(:rap_error_password_reuse, min_unique)) unless unique_enough?(password)
 				end


### PR DESCRIPTION
Hooked into contextual buttons in my/account view to replace Change Password button when it disappears (created a content_tag that is only visible if a user is NOT allowed to change their password)

Added title text to content_tag so an explanation is provided on mouse hover to the user

Added necessary dependency files (hooks.rb) and lines (in init.rb), as well as a few extra labels in en.yml

Issue #8 
