### PR TITLE
Added daily reminder emails to be sent as password expiration nears

### DIFF
--- a/app/views/mailer/notify_password_is_expired.html.erb
+++ b/app/views/mailer/notify_password_is_expired.html.erb
@@ -1,0 +1,17 @@
+<h2><%=l(:rap_mail_body_is_expired_header)%></h2>
+<hr/>
+<p><%=l(:rap_mail_body_is_expired,
+                                name: @user.name,
+                                login: @user.login
+                                )%></p>
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                

--- a/app/views/mailer/notify_password_is_expired.text.erb
+++ b/app/views/mailer/notify_password_is_expired.text.erb
@@ -1,0 +1,7 @@
+<%password_max_age = (Setting.password_max_age.nil? || Setting.password_max_age.to_i.days==0) ? Setting.plugin_redmine_account_policy[:password_max_age].to_i.days : Setting.password_max_age.to_i.days%>
+<h2><%=l(:rap_mail_body_warn_expiry_header)%></h2>
+<%=l(:rap_mail_body_warn_expiry,
+                                name: @user.name,
+                                login: @user.login,
+				days_left: ((((@user.passwd_changed_on || @user.created_on).to_date + password_max_age) - Date.today).to_i)
+                                )%>

--- a/app/views/mailer/notify_password_warn_expiry.html.erb
+++ b/app/views/mailer/notify_password_warn_expiry.html.erb
@@ -1,0 +1,19 @@
+<%password_max_age = (Setting.password_max_age.nil? || Setting.password_max_age.to_i.days==0) ? Setting.plugin_redmine_account_policy[:password_max_age].to_i.days : Setting.password_max_age.to_i.days%>
+<h2><%=l(:rap_mail_body_warn_expiry_header)%></h2>
+<hr />
+<p><%=l(:rap_mail_body_warn_expiry,
+                                name: @user.name,
+                                login: @user.login,
+                                days_left: ((((@user.passwd_changed_on || @user.created_on).to_date + password_max_age) - Date.today).to_i)
+                                )%></p>
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                                                                                                                                  
+~                                                                                                

--- a/app/views/mailer/notify_password_warn_expiry.text.erb
+++ b/app/views/mailer/notify_password_warn_expiry.text.erb
@@ -1,0 +1,7 @@
+<%password_max_age = (Setting.password_max_age.nil? || Setting.password_max_age.to_i.days==0) ? Setting.plugin_redmine_account_policy[:password_max_age].to_i.days : Setting.password_max_age.to_i.days%>
+<h2><%=l(:rap_mail_body_warn_expiry_header)%></h2>
+<%=l(:rap_mail_body_warn_expiry,
+                                name: @user.name,
+                                login: @user.login,
+				days_left: ((((@user.passwd_changed_on || @user.created_on).to_date + password_max_age) - Date.today).to_i)
+                                )%>

--- a/app/views/settings/_account_policy_settings.html.erb
+++ b/app/views/settings/_account_policy_settings.html.erb
@@ -14,20 +14,25 @@
 <p><label><%= l(:rap_setting_password_expiry) %></label></p>
 <p>
 	<%= l(:rap_setting_password_max_age) %>
-	<%= text_field_tag 'settings[password_max_age]', @settings[:password_max_age], size: 1 %>
+	<%= number_field_tag 'settings[password_max_age]', @settings[:password_max_age], min: 0, max: 999 %>
 	<%= l(:label_day_plural) %>
+</br>
+	<%= l(:rap_setting_password_expiry_warn_a) %>
+	<%= number_field_tag 'settings[password_expiry_warn_days]', @settings[:password_expiry_warn_days], min: 0, max: 999 %>
+	<%= l(:label_day_plural) %>
+	<%= l(:rap_setting_password_expiry_warn_b) %>
 </p>
 
 
 <p><label><%= l(:rap_setting_password_reuse) %></label></p>
 <p>
 	<%= l(:rap_setting_password_min_unique_a) %>
-	<%= text_field_tag 'settings[password_min_unique]', @settings[:password_min_unique], size: 1 %>
+	<%= number_field_tag 'settings[password_min_unique]', @settings[:password_min_unique], min: 0, max: 99 %>
 	<%= l(:rap_setting_password_min_unique_b) %>
 </p>
 <p>
 	<%= l(:rap_setting_password_min_age) %>
-	<%= text_field_tag 'settings[password_min_age]', @settings[:password_min_age], size: 1 %>
+	<%= number_field_tag 'settings[password_min_age]', @settings[:password_min_age], min: 0, max: 999 %>
 	<%= l(:label_day_plural) %>
 </p>
 
@@ -35,9 +40,9 @@
 <p><label><%= l(:rap_setting_invalid_logins) %></label></p>
 <p>
 	<%= l(:rap_setting_invalid_logins_a) %>
-	<%= text_field_tag 'settings[account_lockout_duration]', @settings[:account_lockout_duration], size: 1 %>
+	<%= number_field_tag 'settings[account_lockout_duration]', @settings[:account_lockout_duration], min: 0, max: 999 %>
 	<%= l(:rap_setting_invalid_logins_b) %>
-	<%= text_field_tag 'settings[account_lockout_threshold]', @settings[:account_lockout_threshold], size: 1 %>
+	<%= number_field_tag 'settings[account_lockout_threshold]', @settings[:account_lockout_threshold], min: 0, max: 99 %>
 	<%= l(:rap_setting_invalid_logins_c) %>
 </p>
 <p>
@@ -50,7 +55,7 @@
 <p><label><%= l(:rap_setting_unused_account) %></label></p>
 <p>
 	<%= l(:rap_setting_unused_account_max_age) %>
-	<%= text_field_tag 'settings[unused_account_max_age]', @settings[:unused_account_max_age], size: 1 %>
+	<%= number_field_tag 'settings[unused_account_max_age]', @settings[:unused_account_max_age], min: 0, max: 99 %>
 	<%= l(:label_day_plural) %>
 </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,8 +15,17 @@ en:
     # == password expiry == #
   rap_setting_password_expiry:        'Password Expiry'
   rap_setting_password_max_age:       'Maximum password age'
+  rap_setting_password_expiry_warn_a: 'Email warning notifications start'
+  rap_setting_password_expiry_warn_b: 'before password expiration'
   rap_notice_password_expired:        'Your password has expired.'
+ 
+  rap_mail_subject_warn_expiry:       'Warning - Password Expiration in %{days_left} Days'
+  rap_mail_body_warn_expiry_header:   'Password Expiration Warning'
+  rap_mail_body_warn_expiry:          'The password of your account "%{name}" [%{login}] will expire in %{days_left} days. Please log in and update your password before this occurs.' 
 
+  rap_mail_subject_is_expired:       'Password Expired'
+  rap_mail_body_is_expired_header:   'Password Expiration Notice'
+  rap_mail_body_is_expired:          'The password of your account "%{name}" [%{login}] has expired.' 
 
     # == password reuse == #
   rap_setting_password_reuse:         'Password Reuse'

--- a/init.rb
+++ b/init.rb
@@ -23,6 +23,7 @@ Redmine::Plugin.register :redmine_account_policy do
 
 		# password expiry policy
 		password_max_age: '90',
+		password_expiry_warn_days: '14',
 
 		# password reuse policy
 		password_min_unique: '1', #TODO: Redmine checks new vs current

--- a/lib/redmine_account_policy/mailer_patch.rb
+++ b/lib/redmine_account_policy/mailer_patch.rb
@@ -19,6 +19,19 @@ module RedmineAccountPolicy
         	admins = User.active.select { |u| u.admin? }.map(&:mail)
 					mail to: user.mail, bcc: admins, subject: l(:rap_mail_subject_login_lockout)
         end
+        
+	def notify_password_warn_expiry(user)
+					@user = user
+					password_max_age = (Setting.password_max_age.to_i.days==0) ? Setting.plugin_redmine_account_policy[:password_max_age].to_i.days : Setting.password_max_age.to_i.days
+
+					mail to: user.mail, subject: l(:rap_mail_subject_warn_expiry, days_left: ((((@user.passwd_changed_on || @user.created_on).to_date + password_max_age) - Date.today).to_i))
+        end
+	
+	def notify_password_is_expired(user)
+					@user = user
+					mail to: user.mail, subject: l(:rap_mail_subject_warn_expiry)
+        end
+
 
         def set_instance_variables(user, ip_address)
         	# set instance variables to use in mailer views


### PR DESCRIPTION
Current functionality really only works with Redmine 3.x, as existing code uses Setting.password_max_age, a hash key that doesn't exist in 2.x.

Compatibility attempted with some lines, but account policy as it stands likely will not work if code remains the same. Regardless, mail templates and functions created and tied into daily tasks run per day.

Also made some changes to settings page, ensure all text boxes are number boxes (excepting the password complexity box, as that should be a dropdown, not a number field at all)
