### PR TITLE
Show account lock on all attempts to prevent brute force on locked accounts

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,9 @@ en:
   rap_mail_body_login_lockout_header: 'Maximum allowed login attempts reached'
   rap_mail_body_login_failure:        'An unsuccessful attempt to login to your account was made from %{ip_address}.'
   rap_mail_body_login_lockout:        'Your account "%{name}" [%{login}] reached its maximum allowed number fo failed login attempts.  The last attempt was from %{ip_address}.  Your account has been locked for %{lockout_duration} minutes.'
+ 
+  rap_account_locked_due_to_account_policy: 'Unlock (locked due to max fails - please hover)'
+  rap_alt_account_locked_due_to_account_policy: 'This account has been locked because it has reached the maximum number of failed login attempts. To lock this account such that the user cannot unlock themselves once their timeout expires, please unlock and re-lock this user account.'
 
 
     # == unused accounts == #

--- a/init.rb
+++ b/init.rb
@@ -5,6 +5,7 @@ require_dependency 'redmine_account_policy/controller_account_success_authentica
 require_dependency 'redmine_account_policy/mailer_patch'
 require_dependency 'redmine_account_policy/my_controller_patch'
 require_dependency 'redmine_account_policy/user_patch'
+require_dependency 'redmine_account_policy/users_helper_patch'
 
 Redmine::Plugin.register :redmine_account_policy do
 	name 'Redmine Account Policy plugin'

--- a/lib/redmine_account_policy/account_controller_patch.rb
+++ b/lib/redmine_account_policy/account_controller_patch.rb
@@ -121,8 +121,15 @@ module RedmineAccountPolicy
 			#invalid credentials cache), don't enter them into the cache (otherwise they can unlock themselves by failing out and
 			#entering the right password)
 			if username.blank? || lockout_duration == 0 || (counter.nil? && is_locked?(user_from_login))
+				#because code already exposes locked accounts, ensure that 'locked account' message is returned on *every attempt*
+				#otherwise, attackers can determine passwords of locked accounts
+				if (counter.nil? && is_locked?(user_from_login))
+					redirect_to signin_path unless performed?
+					flash[:error] = l(:notice_account_locked)
+				else
 				# pass username back to Redmine's default handler
 				invalid_credentials_without_account_policy
+				end
 				# now let's deal with invalid passwords
 			else
 				if counter.nil?

--- a/lib/redmine_account_policy/users_helper_patch.rb
+++ b/lib/redmine_account_policy/users_helper_patch.rb
@@ -1,0 +1,33 @@
+module RedminePasswordPolicy
+	module Patches
+		module UsersHelperPatch
+
+			def self.included(base)
+				base.send(:include, InstanceMethods)
+
+				# Wrap the methods we are extending
+				base.alias_method_chain :change_status_link, :account_policy
+			end
+
+			module InstanceMethods
+				def change_status_link_with_account_policy(user)
+					#changes link text and adds title text if user is only *temporarily locked* - 
+					#in other words, changes link text such that administrator can identify which
+					#users are fully locked and which users are only locked until their timeout has expired
+					url = {:controller => 'users', :action => 'update', :id => user, :page => params[:page], :status => params[:status], :tab => nil}
+					counter = $invalid_credentials_cache[user.login.downcase]
+					if user.locked? && counter && counter.is_a?(Time) && counter == user.updated_on   
+						link_to l(:rap_account_locked_due_to_account_policy), url.merge(:user => {:status => User::STATUS_ACTIVE}),:title => l(:rap_alt_account_locked_due_to_account_policy), :method => :put, :class => 'icon icon-unlock'
+					else
+						change_status_link_without_account_policy(user)
+					end
+				end
+			end
+
+		end
+	end
+end
+
+UsersHelper.send :include, RedminePasswordPolicy::Patches::UsersHelperPatch
+
+


### PR DESCRIPTION
Current code implementation on branch UseDefaultRedmineLockFunctionalityOnMaxFailInsteadOfBlockingAllLoginAttempts exposes locked accounts.

   Current behaviour shows 'Invalid user or password' for wrong passwords and 'Your account is locked' for all correct password attempts on a locked user account. 

  This patch overrides this behaviour and displays "Your account is locked" on any valid username that is currently locked, whether the password is right or wrong.

```
Attackers can link usernames to passwords and access website if lock is ever lifted or, in worst case, access that user's other accounts.
```
