### PR TITLE
make sure Redmine settings are saved and used

### DIFF
--- a/app/views/hooks/redmine_account_policy/_view_my_account_contextual.erb
+++ b/app/views/hooks/redmine_account_policy/_view_my_account_contextual.erb
@@ -1,2 +1,2 @@
 
-<%=content_tag(:span, l(:button_change_password), :style => "color:gray", :class=>"icon icon-passwd", :title => l(:rap_alt_change_passwords_not_allowed, time_of_lockout_in_hours: (Setting.plugin_redmine_account_policy[:password_min_age].to_i * 24).to_s)) unless @user.change_password_allowed? %>
+<%=content_tag(:span, l(:button_change_password), :style => "color:gray", :class=>"icon icon-passwd", :title => l(:rap_alt_change_passwords_not_allowed, time_of_lockout_in_hours: (Setting.plugin_redmine_account_policy['password_min_age'].to_i * 24).to_s)) unless @user.change_password_allowed? %>

--- a/app/views/mailer/notify_account_lockout.html.erb
+++ b/app/views/mailer/notify_account_lockout.html.erb
@@ -4,5 +4,5 @@
 				name: @user.name,
 				login: @user.login,
 				ip_address: @ip_address,
-					lockout_duration: Setting.plugin_redmine_account_policy[:account_lockout_duration].to_s
+					lockout_duration: Setting.plugin_redmine_account_policy['account_lockout_duration'].to_s
 				)%></p>

--- a/app/views/mailer/notify_account_lockout.text.erb
+++ b/app/views/mailer/notify_account_lockout.text.erb
@@ -3,5 +3,5 @@
 				name: @user.name,
 				login: @user.login,
 				ip_address: @ip_address,
-					lockout_duration: Setting.plugin_redmine_account_policy[:account_lockout_duration].to_s
+					lockout_duration: Setting.plugin_redmine_account_policy['account_lockout_duration'].to_s
 				)%>

--- a/app/views/mailer/notify_password_is_expired.text.erb
+++ b/app/views/mailer/notify_password_is_expired.text.erb
@@ -1,4 +1,4 @@
-<%password_max_age = Setting.plugin_redmine_account_policy[:password_max_age].to_i.days%>
+<%password_max_age = Setting.plugin_redmine_account_policy['password_max_age'].to_i.days%>
 <h2><%=l(:rap_mail_body_warn_expiry_header)%></h2>
 <%=l(:rap_mail_body_warn_expiry,
                                 name: @user.name,

--- a/app/views/mailer/notify_password_warn_expiry.html.erb
+++ b/app/views/mailer/notify_password_warn_expiry.html.erb
@@ -1,4 +1,4 @@
-<%password_max_age = Setting.plugin_redmine_account_policy[:password_max_age].to_i.days%>
+<%password_max_age = Setting.plugin_redmine_account_policy['password_max_age'].to_i.days%>
 <h2><%=l(:rap_mail_body_warn_expiry_header)%></h2>
 <hr />
 <p><%=l(:rap_mail_body_warn_expiry, 

--- a/app/views/mailer/notify_password_warn_expiry.text.erb
+++ b/app/views/mailer/notify_password_warn_expiry.text.erb
@@ -1,4 +1,4 @@
-<%password_max_age = Setting.plugin_redmine_account_policy[:password_max_age].to_i.days%>
+<%password_max_age = Setting.plugin_redmine_account_policy['password_max_age'].to_i.days%>
 <h2><%=l(:rap_mail_body_warn_expiry_header)%></h2>
 <%=l(:rap_mail_body_warn_expiry,
                                 name: @user.name,

--- a/app/views/settings/_account_policy_settings.html.erb
+++ b/app/views/settings/_account_policy_settings.html.erb
@@ -4,7 +4,7 @@
 
 <p>
 	<%= l(:rap_setting_password_complexity_a) %>
-    <%= select_tag 'settings[password_complexity]', options_for_select([0,1,2,3,4], @settings[:password_complexity]) %>
+    <%= select_tag 'settings[password_complexity]', options_for_select([0,1,2,3,4], @settings['password_complexity']) %>
 	<%= l(:rap_setting_password_complexity_b) %>
 	</br>
 	<%= l(:rap_setting_password_upper_case)   %></br>
@@ -17,11 +17,11 @@
 <p><label><%= l(:rap_setting_password_expiry) %></label></p>
 <p>
 	<%= l(:rap_setting_password_max_age) %>
-	<%= number_field_tag 'settings[password_max_age]', @settings[:password_max_age], min: 0, max: 999 %>
+	<%= number_field_tag 'settings[password_max_age]', @settings['password_max_age'], min: 0, max: 999 %>
 	<%= l(:label_day_plural) %>
 </br>
 	<%= l(:rap_setting_password_expiry_warn_a) %>
-	<%= number_field_tag 'settings[password_expiry_warn_days]', @settings[:password_expiry_warn_days], min: 0, max: 999 %>
+	<%= number_field_tag 'settings[password_expiry_warn_days]', @settings['password_expiry_warn_days'], min: 0, max: 999 %>
 	<%= l(:label_day_plural) %>
 	<%= l(:rap_setting_password_expiry_warn_b) %>
 </p>
@@ -30,12 +30,12 @@
 <p><label><%= l(:rap_setting_password_reuse) %></label></p>
 <p>
 	<%= l(:rap_setting_password_min_unique_a) %>
-	<%= number_field_tag 'settings[password_min_unique]', @settings[:password_min_unique], min: 1, max: 30%>
+	<%= number_field_tag 'settings[password_min_unique]', @settings['password_min_unique'], min: 1, max: 30%>
 	<%= l(:rap_setting_password_min_unique_b) %>
 </p>
 <p>
 	<%= l(:rap_setting_password_min_age) %>
-	<%= number_field_tag 'settings[password_min_age]', @settings[:password_min_age], min: 0, max: 999 %>
+	<%= number_field_tag 'settings[password_min_age]', @settings['password_min_age'], min: 0, max: 999 %>
 	<%= l(:label_day_plural) %>
 </p>
 
@@ -43,13 +43,13 @@
 <p><label><%= l(:rap_setting_invalid_logins) %></label></p>
 <p>
 	<%= l(:rap_setting_invalid_logins_a) %>
-	<%= number_field_tag 'settings[account_lockout_duration]', @settings[:account_lockout_duration], min: 0, max: 999 %>
+	<%= number_field_tag 'settings[account_lockout_duration]', @settings['account_lockout_duration'], min: 0, max: 999 %>
 	<%= l(:rap_setting_invalid_logins_b) %>
-	<%= number_field_tag 'settings[account_lockout_threshold]', @settings[:account_lockout_threshold], min: 0, max: 99 %>
+	<%= number_field_tag 'settings[account_lockout_threshold]', @settings['account_lockout_threshold'], min: 0, max: 99 %>
 	<%= l(:rap_setting_invalid_logins_c) %>
 </p>
 <p>
-	<%= check_box_tag 'settings[notify_on_failure]', params[:notify_on_failure], @settings[:notify_on_failure] %>
+	<%= check_box_tag 'settings[notify_on_failure]', params[:notify_on_failure], @settings['notify_on_failure'] %>
 	<%= l(:rap_setting_notify_on_failure) %>
 </p>
 <p><em class="info"><%= l(:rap_setting_notify_on_lockout) %></em></p>
@@ -58,12 +58,12 @@
 <p><label><%= l(:rap_setting_unused_account) %></label></p>
 <p>
 	<%= l(:rap_setting_unused_account_max_age) %>
-	<%= number_field_tag 'settings[unused_account_max_age]', @settings[:unused_account_max_age], min: 0, max: 99 %>
+	<%= number_field_tag 'settings[unused_account_max_age]', @settings['unused_account_max_age'], min: 0, max: 99 %>
 	<%= l(:label_day_plural) %>
 </p>
 
 
 <p>
 	<label><%= l(:rap_setting_account_policy_checked_on) %></label>
-	<%= text_field_tag('settings[account_policy_checked_on]', Setting.plugin_redmine_account_policy[:account_policy_checked_on], readonly: true, style: 'text-align: center;color:#5f5f5f;border:transparent')%>
+	<%= text_field_tag('settings[account_policy_checked_on]', Setting.plugin_redmine_account_policy['account_policy_checked_on'], readonly: true, style: 'text-align: center;color:#5f5f5f;border:transparent')%>
 </p>

--- a/lib/redmine_account_policy/mailer_patch.rb
+++ b/lib/redmine_account_policy/mailer_patch.rb
@@ -14,7 +14,7 @@ module RedmineAccountPolicy
         end
 
         def notify_account_lockout(user, ip_address)
-          notify_user = Setting.plugin_redmine_account_policy[:notify_on_lockout]
+          notify_user = Setting.plugin_redmine_account_policy['notify_on_lockout']
           set_instance_variables(user, ip_address)
 
           recipients = User.active.select { |u| u.admin? }.map(&:mail)

--- a/lib/redmine_account_policy/user_patch.rb
+++ b/lib/redmine_account_policy/user_patch.rb
@@ -30,7 +30,7 @@ module RedmineAccountPolicy
             if !complex_enough?(password)
               errors.add(:base, 
                          l(:rap_error_password_complexity, 
-                           complexity: Setting.plugin_redmine_account_policy[:password_complexity])) 
+                           complexity: Setting.plugin_redmine_account_policy['password_complexity'])) 
             end
           end		
         end
@@ -40,7 +40,7 @@ module RedmineAccountPolicy
 
         # TODO: should be in, for example, an ApplicationPatch module
         def password_max_age
-          Setting.plugin_redmine_account_policy[:password_max_age].to_i
+          Setting.plugin_redmine_account_policy['password_max_age'].to_i
         end
 
         # TODO: should be in, for example, an ApplicationPatch module
@@ -71,7 +71,7 @@ module RedmineAccountPolicy
         # == password reuse == #
 
         def change_password_allowed_with_account_policy?
-          min_age = Setting.plugin_redmine_account_policy[:password_min_age].to_i
+          min_age = Setting.plugin_redmine_account_policy['password_min_age'].to_i
           unless passwd_changed_on.blank?
             return false if passwd_changed_on > (Time.zone.now - min_age.days)
           end
@@ -83,7 +83,7 @@ module RedmineAccountPolicy
 
         # TODO: should be in, for example, an ApplicationPatch module
         def unused_account_max_age
-          Setting.plugin_redmine_account_policy[:unused_account_max_age].to_i
+          Setting.plugin_redmine_account_policy['unused_account_max_age'].to_i
         end
 
         # TODO: should be in, for example, an ApplicationPatch module
@@ -100,7 +100,7 @@ module RedmineAccountPolicy
         private
 
         def complex_enough?(password)
-          complexity = Setting.plugin_redmine_account_policy[:password_complexity].to_i
+          complexity = Setting.plugin_redmine_account_policy['password_complexity'].to_i
           return true if complexity == 0
 
           count = 0


### PR DESCRIPTION
In newer Ruby (2.4.6) and Redmine (3.4.10) versions Redmine settings are not handled as HashWithIndifferentAccess, so using symbols for setting keys do not work anymore. You can try the behavior by going to Redmine Admin plugin settings page and try to change plugin settings, you will notice saving the settings will not work. These changes should fix that.